### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,4 +1,6 @@
 name: Rust
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/MituuZ/convo-forge/security/code-scanning/1](https://github.com/MituuZ/convo-forge/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow file, specifying the least privilege required. Since the workflow only checks out code and runs build/test commands, it only needs read access to repository contents. The best way to fix this is to add `permissions: contents: read` at the top level of the workflow file, just below the `name:` and before the `on:` key. This ensures all jobs in the workflow inherit these minimal permissions unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
